### PR TITLE
Added Overlay class to display level information

### DIFF
--- a/src/objects/Overlay.js
+++ b/src/objects/Overlay.js
@@ -1,0 +1,31 @@
+import "phaser";
+
+
+export default class Overlay extends Phaser.GameObjects.Group{
+
+    DEPTH = 1000;
+
+    constructor(scene, levelName)
+    {
+        super(scene);
+
+        this.add(
+            new Phaser.GameObjects.Text(
+                scene,
+                scene.cameras.main.width,
+                0, 
+                levelName)
+                .setStyle({
+                    fontSize: '24px',
+                    fontFamily: 'Arial',
+                    color: 'rgb(255, 255, 255)',
+                    backgroundColor: 'rgba(0, 0, 0, 0.5)'
+                })
+                .setOrigin(1, 0)   //  sets origin to upper right corner of text
+                .setPadding(20, 10, 20, 10)
+                .setScrollFactor(0, 0)
+                .setDepth(this.DEPTH),
+            true);
+    }
+
+}


### PR DESCRIPTION
#### Description
Added an overlay class to hold level information. Currently the constructor takes a level name and displays it in the upper right corner of a scene.
<br>

#### Testing
Tested locally.

![image](https://user-images.githubusercontent.com/16170334/76884769-9421b500-6854-11ea-9228-5232085c63ec.png)
